### PR TITLE
Issue66: Fixes opening tag for hero component.

### DIFF
--- a/generators/starter-kit/templates/hero/hero.twig
+++ b/generators/starter-kit/templates/hero/hero.twig
@@ -1,6 +1,6 @@
 {{ attach_library('<%= themeNameMachine %>/hero') }}
 
-<div class="hero {{ modifier }}" {{ extra_attributes }}>
+<section class="hero {{ modifier }}" {{ extra_attributes }}>
   {#
     Optional: Pass in Drupal specific functionality.
     Note that this is mostly relevant to nodes and blocks.


### PR DESCRIPTION
Replaced `div` for `section` on hero component.  Closing tag already reflected correct `section` tag.