### PR TITLE
Adding style lint fix script

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -8,6 +8,7 @@
     "styleguide": "gulp styleguide",
     "compress": "gulp compress",
     "lint": "gulp lint",
+    "scss-fix": "npx stylelint './src/**/*.scss' --fix",
     "clean": "gulp clean",
     "gulp": "gulp",
     "generate": "yo mc-d8-theme:component"


### PR DESCRIPTION
This adds a small script into the package.json to fix linting errors.
When run, it starts stylelint which checks for linting errors that can be fixed automatically and then fixes them. This is built-in stylelint functionality so no new installation or anything is necessary.