### PR TITLE
Update README.md to suggest installing node v14

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ While not a requirement we like to use [NVM](https://github.com/creationix/nvm) 
     ```
 
     ```bash
-    nvm install 14.16.1 && node -v > .nvmrc
+    nvm install 14 && node -v > .nvmrc
     ```
 
-    - This will install version NodeJS `v14.16.1`.
+    - This will install the latest release of NodeJS `v14`.
 
     - It will create `.nvmrc` in the root of your project.
 


### PR DESCRIPTION
Instead of hardcoding the instructions to use a specific point release of node, this tells it to use the v14 branch.